### PR TITLE
Mark LocationDetails.geoCoordinates as optional

### DIFF
--- a/src/types/restfulTypes.ts
+++ b/src/types/restfulTypes.ts
@@ -293,7 +293,7 @@ export type GeoCoordinates = {
 
 export type LocationDetails = {
     address: Address
-    geoCoordinates: GeoCoordinates
+    geoCoordinates?: GeoCoordinates
 }
 
 export type InventoryLocationFull = InventoryLocation & {


### PR DESCRIPTION
eBay marks this field as optional at https://developer.ebay.com/api-docs/sell/inventory/resources/location/methods/createInventoryLocation#request.location.geoCoordinates