### PR TITLE
fix: Make EbayOfferDetailsWithKeys.merchantLocationKey optional

### DIFF
--- a/src/types/restfulTypes.ts
+++ b/src/types/restfulTypes.ts
@@ -450,7 +450,7 @@ export type EbayOfferDetailsWithKeys = {
     listingDescription?: string,
     listingDuration?: string,
     listingPolicies: ListingPolicies,
-    merchantLocationKey: string,
+    merchantLocationKey?: string,
     pricingSummary: PricingSummary,
     quantityLimitPerBuyer?: number,
     secondaryCategoryId?: string,


### PR DESCRIPTION
Ebay's docs say it is required, but in practice their endpoint accepts requests without a merchant location key.
In fact, they reject requests that have two otherwise identical offers with different merchant location keys
with the error message "User input error. The combination of SKU, marketplaceId and format should be unique."