### PR TITLE
fix: Remove sku from Compatibility

### DIFF
--- a/src/types/restfulTypes.ts
+++ b/src/types/restfulTypes.ts
@@ -1088,7 +1088,6 @@ export type CompatibleProduct = {
 
 export type Compatibility = {
     compatibleProducts: CompatibleProduct[]
-    sku: string
 }
 
 export type Specification = {


### PR DESCRIPTION
From the eBay docs:

> For the createOrReplaceProductCompatibility call, the SKU value for the inventory item is actually passed in as part of the call URI, and not in the request payload.

Source: https://developer.ebay.com/api-docs/sell/inventory/resources/inventory_item/product_compatibility/methods/createOrReplaceProductCompatibility#request.sku 