### PR TITLE
Fixed fetchItemAspects return error

### DIFF
--- a/src/api/restful/commerce/taxonomy/index.ts
+++ b/src/api/restful/commerce/taxonomy/index.ts
@@ -131,6 +131,8 @@ export default class Taxonomy extends Api {
      */
     public fetchItemAspects(categoryTreeId: string) {
         const cId = encodeURIComponent(categoryTreeId);
-        return this.get(`/category_tree/${cId}/fetch_item_aspects`);
+        return this.get(`/category_tree/${cId}/fetch_item_aspects`, {
+            responseType: 'arraybuffer'
+        });
     }
 }

--- a/src/api/restful/commerce/taxonomy/index.ts
+++ b/src/api/restful/commerce/taxonomy/index.ts
@@ -127,9 +127,11 @@ export default class Taxonomy extends Api {
     /**
      * This call returns a complete list of aspects for all of the leaf categories that belong to an eBay marketplace.
      *
-     *  @param categoryTreeId
+     * @param categoryTreeId
+     *
+     * @return A JSON GZIP compressed file buffer
      */
-    public fetchItemAspects(categoryTreeId: string) {
+    public fetchItemAspects(categoryTreeId: string): Promise<Buffer> {
         const cId = encodeURIComponent(categoryTreeId);
         return this.get(`/category_tree/${cId}/fetch_item_aspects`, {
             responseType: 'arraybuffer'


### PR DESCRIPTION
Closes #29

Added a response type so Axios can decipher what is being returned. Current implementation lets users handle decompressing the data on their side.

Decompression example:
```javascript
(async (ebayApiInstance, categoryTreeId) => {
  try {
    const data = await ebayApiInstance.commerce.taxonomy.fetchItemAspects(categoryTreeId);

    return new Promise((resolve) => {
      zlib.gunzip(data, (err, output) => {
        if (err) throw err;

        resolve(output.toString());
      });
    });
  } catch (err) {
    console.log(err.response);
    return Promise.reject(err);
  };)();
```