### PR TITLE
Added sort parameter to getPayouts

### DIFF
--- a/src/api/restful/sell/finances/index.ts
+++ b/src/api/restful/sell/finances/index.ts
@@ -48,7 +48,7 @@ export default class Finances extends Restful {
     filter?: string;
     limit?: number;
     offset?: number;
-    sort:?: 'payoutDate' | '-payoutDate';
+    sort?: 'payoutDate' | '-payoutDate';
   } = {}) {
     return this.get(`/payout`, {
       params: {


### PR DESCRIPTION
The api allows sorting payouts by payoutDate.

https://developer.ebay.com/api-docs/sell/finances/resources/payout/methods/getPayouts