### PR TITLE
Fix eBay.postOrder.case.search(order_id)

### DIFF
--- a/src/api/restful/postOrder/case/index.ts
+++ b/src/api/restful/postOrder/case/index.ts
@@ -95,9 +95,7 @@ export default class Case extends Restful {
    */
   public search(params: CaseSearchParams) {
     return this.get(`/casemanagement/search`, {
-      params: {
-        params
-      }
+      params
     });
   }
 }


### PR DESCRIPTION
A function eBay.postOrder.case.search(params) was broken and params were not provided to the server correctly.
This was fixed and tested.