### PR TITLE
fix: :bug: fixes search cancellations request with query parameters

### DIFF
--- a/src/api/restful/postOrder/cancellation/index.ts
+++ b/src/api/restful/postOrder/cancellation/index.ts
@@ -97,9 +97,7 @@ export default class Cancellation extends Restful {
    */
   public search(params: CancellationSearchParams) {
     return this.get(`/cancellation/search`, {
-      params: {
-        params
-      }
+      params
     });
   }
 }


### PR DESCRIPTION
Due to params being nested twice, the query string was wrongly formed in the request causing the error 400 bad request being returned by ebay api. Worked fine with not parameters were passed