### PR TITLE
fix: Added responseType and responseEncoding to getLatestResultFile/getResultFile for files to download correctly

### DIFF
--- a/src/api/restful/sell/feed/index.ts
+++ b/src/api/restful/sell/feed/index.ts
@@ -172,7 +172,10 @@ export default class Feed extends Restful implements OpenApi<operations> {
    */
   public getLatestResultFile(scheduleId: string) {
     scheduleId = encodeURIComponent(scheduleId);
-    return this.get(`/schedule/${scheduleId}/download_result_file`);
+    return this.get(`/schedule/${scheduleId}/download_result_file`, {
+      responseType: 'arraybuffer',
+      responseEncoding: 'binary',
+  });
   }
 
   /**
@@ -262,7 +265,10 @@ export default class Feed extends Restful implements OpenApi<operations> {
    */
   public getResultFile(taskId: string) {
     taskId = encodeURIComponent(taskId);
-    return this.get(`/task/${taskId}/download_result_file`);
+    return this.get(`/task/${taskId}/download_result_file`, {
+      responseType: 'arraybuffer',
+      responseEncoding: 'binary',
+  });
   }
 
   /**


### PR DESCRIPTION
While working with the getResultFile method to download the result file from ebay, I was getting an error when trying to decompress the file, after some digging I realized the file wasn't downloading correct so I added responseType and responseEncoding to the getLatestResultFile/getResultFile methods and that seems to fix the issues.