### PR TITLE
ci: run lint and typecheck, and trigger on pushes to master

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,8 @@ name: Test
 on:
   pull_request:
     branches: [master]
+  push:
+    branches: [master]
 
 jobs:
   test:
@@ -14,4 +16,6 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
+      - run: npm run lint
+      - run: npm run typecheck
       - run: npm test


### PR DESCRIPTION
The Test workflow only ran `npm test`, and only on pull requests.

- **`npm run lint`** — lint had no CI protection at all, so the eslint fixes in `beb7e46` could regress unnoticed.
- **`npm run typecheck`** — nothing type-checked `test/` or `examples/`. That is how an extensionless import survived in `examples/traditional/clientAlerts.GetPublicAlerts.ts` until it was found by hand during the v10 review; `tsconfig.check.json` covers `src`, `test` and `examples`.
- **push trigger on `master`** — merges and any direct pushes are now verified, not just PRs.

The `push` filter is scoped to `master`, so PR branches still fire only the `pull_request` event and nothing runs twice.

## Test plan

- [x] `npm run lint` clean on master
- [x] `npm run typecheck` clean on master
- [x] `npm test` — 1371 passing
- [ ] `pull_request` run green on this PR
- [ ] `push` run green after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)